### PR TITLE
Use system libffi on macOS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ ifeq ($(UNAME_S),Linux)
 	QP=l
 endif
 ifeq ($(UNAME_S),Darwin)
-  FFI_INCLUDE=`pkg-config --cflags  /usr/local/Cellar/libffi/3.2.1/lib/pkgconfig/libffi.pc`
-	FFI_LIBS=`pkg-config --libs /usr/local/Cellar/libffi/3.2.1/lib/pkgconfig/libffi.pc`
+  FFI_INCLUDE=-I /usr/include/ffi
+	FFI_LIBS=-lffi
 	OPTS=-g -shared  -undefined dynamic_lookup  -mmacosx-version-min=10.12 -ldl -Wall
 	CC=clang
 	QP=m

--- a/ffi.c
+++ b/ffi.c
@@ -13,6 +13,11 @@
 #else
 #define EXP
 #endif
+#if defined(MACOSX)
+#define ffi_prep_closure_loc(closure, cif, func, data, loc) \
+  ffi_prep_closure(closure, cif, func, data)
+#define ffi_closure_alloc(size, code) malloc(size)
+#endif
 
 #define KXVER 3
 #include "k.h"


### PR DESCRIPTION
Adjust the build logic and the C code to make ffi.q use system libffi on macOS.  The code changes are required because macOS ships with an older version of libffi which does not have some of the new libffi functions.

See also e874aef20b608220ff3a7ce54b55cd98e2fc4b64.